### PR TITLE
Added endpoint '/api/articles/:article_id' with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -40,6 +40,33 @@ describe("/api/topics",()=>{
     })
 })
 
+describe("/api/topics",()=>{
+    test("GET 200 and the requested article by id", () => {
+        return request(app)
+            .get("/api/articles/1")
+            .expect(200)
+                .then(({body})=>{
+                    const {article} = body
+                    expect(article.title).toBe("Living in the shadow of a great man")
+                    expect(article.topic).toBe("mitch")
+                    expect(article.author).toBe("butter_bridge")
+                    expect(article.body).toBe("I find this existence challenging")
+                    expect(article.created_at).toBe("2020-07-09T20:11:00.000Z")
+                    expect(article.votes).toBe(100)
+                    expect(article.article_img_url).toBe("https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700")
+                })
+    })
+    test("GET 404 when given an invalid article_id",()=>{
+        return request(app)
+            .get("/api/articles/100")
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Invalid article_id")
+                })
+    })
+})
+
 describe("Invalid endpoint", () => {
     test("GET 404 where the request is not found", () => {
         return request(app)

--- a/app.js
+++ b/app.js
@@ -1,13 +1,15 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById } = require("./controllers/controllers")
 
 // app.use(express.json())
 
 app.get('/api', getAllEndpoints)
 
 app.get('/api/topics', getAllTopics)
+
+app.get('/api/articles/:article_id', getArticleById)
 
 
 app.use((req, res, next) => {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,4 @@
-const { selectAllTopics, selectAllEndpoints }= require("../models/models")
+const { selectAllTopics, selectAllEndpoints, selectArticleById }= require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -7,12 +7,30 @@ exports.getAllEndpoints = (req, res, next) => {
 
 exports.getAllTopics = (req, res, next) => {
     selectAllTopics()
-    .then(({rows}) => {
+    .then(({ rows }) => {
         const topics = rows
 
         res.status(200).send({topics})
     })
     .catch((err) => {
         next(err)
+    })
+}
+
+exports.getArticleById = (req, res, next) => {
+    const { article_id } = req.params
+    selectArticleById(article_id)
+    .then(({ rows }) => {
+        if (rows.length === 0) {
+            const err = {
+                status: 404,
+                msg: 'Invalid article_id'
+            }
+            next(err)
+        } else {
+            const article = rows[0]
+    
+            res.status(200).send({article})
+        }
     })
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -25,5 +25,22 @@
         }
       ]
     }
+  }, 
+  "GET /api/articles/:article_id": {
+    "description": "serves an array of of the requested article",
+    "queries": ["article_id"],
+    "exampleResponse": {
+      "article": [
+        {
+          "title": "Living in the shadow of a great man",
+          "topic": "mitch",
+          "author": "butter_bridge",
+          "body": "I find this existence challenging",
+          "created_at": "2020-07-09T20:11:00.000Z",
+          "votes": 100,
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        }
+      ]
+    }
   }
 }

--- a/models/models.js
+++ b/models/models.js
@@ -10,3 +10,11 @@ exports.selectAllTopics = () => {
 
     return db.query(queryStr)
 }
+
+exports.selectArticleById = (id) => {
+    let queryStr = `SELECT * FROM articles`
+
+    queryStr += ` WHERE article_id = ${id}`
+
+    return db.query(queryStr)
+}


### PR DESCRIPTION
Added endpoint '/api/articles/:article_id' where the endpoint returns the title, topic, author, body, created_at, votes and the article_image_url of the requested arrticle_id for the happy path.

Added error handling if the author_id provided is invalid with msg (invalid authour_id) for the sad path.

Also added the new endpoint to the endpoint.JSON 

(the previous example had comment_count instead of the article_img_url not sure if there is an error or if that is a future task)