### PR TITLE
Added endpoint '/api/articles' with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -40,7 +40,29 @@ describe("/api/topics",()=>{
     })
 })
 
-describe("/api/topics",()=>{
+describe("/api/articles",()=>{
+    test("GET 200 and all articles upon request", () => {
+        return request(app)
+            .get("/api/articles")
+            .expect(200)
+                .then(({body})=>{
+                    const {articles} = body
+                    expect(articles.length).toBe(13)
+                    articles.forEach((article)=>{
+                        expect(typeof article.article_id).toBe("number")
+                        expect(typeof article.author).toBe("string")
+                        expect(typeof article.title).toBe("string")
+                        expect(typeof article.topic).toBe("string")
+                        expect(typeof article.created_at).toBe("string")
+                        expect(typeof article.votes).toBe("number")
+                        expect(typeof article.article_img_url).toBe("string")
+                        expect(typeof article.comment_count).toBe("string")
+                    })
+                })
+    })
+})
+
+describe("/api/articles/:article_id",()=>{
     test("GET 200 and the requested article by id", () => {
         return request(app)
             .get("/api/articles/1")
@@ -56,9 +78,18 @@ describe("/api/topics",()=>{
                     expect(article.article_img_url).toBe("https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700")
                 })
     })
-    test("GET 404 when given an invalid article_id",()=>{
+    test("GET 404 when given an valid but non-existent article_id",()=>{
         return request(app)
             .get("/api/articles/100")
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("article_id does not exist")
+                })
+    })
+    test("GET 404 when given an valid but non-existent article_id",()=>{
+        return request(app)
+            .get("/api/articles/banana")
             .expect(404)
                 .then(({body})=>{
                     const {msg} = body

--- a/app.js
+++ b/app.js
@@ -1,13 +1,15 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints, getArticleById } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles } = require("./controllers/controllers")
 
 // app.use(express.json())
 
 app.get('/api', getAllEndpoints)
 
 app.get('/api/topics', getAllTopics)
+
+app.get('/api/articles', getAllArticles)
 
 app.get('/api/articles/:article_id', getArticleById)
 

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,4 @@
-const { selectAllTopics, selectAllEndpoints, selectArticleById }= require("../models/models")
+const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles }= require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -10,7 +10,19 @@ exports.getAllTopics = (req, res, next) => {
     .then(({ rows }) => {
         const topics = rows
 
-        res.status(200).send({topics})
+        res.status(200).send({ topics })
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
+
+exports.getAllArticles = (req, res, next) => {
+    selectAllArticles()
+    .then(( { rows }) => {
+        const articles = rows
+
+        res.status(200).send({ articles })
     })
     .catch((err) => {
         next(err)
@@ -20,17 +32,10 @@ exports.getAllTopics = (req, res, next) => {
 exports.getArticleById = (req, res, next) => {
     const { article_id } = req.params
     selectArticleById(article_id)
-    .then(({ rows }) => {
-        if (rows.length === 0) {
-            const err = {
-                status: 404,
-                msg: 'Invalid article_id'
-            }
-            next(err)
-        } else {
-            const article = rows[0]
-    
-            res.status(200).send({article})
-        }
+    .then(( article ) => {
+        res.status(200).send({article})
+    })
+    .catch((err) => {
+        next(err)
     })
 }

--- a/models/models.js
+++ b/models/models.js
@@ -11,10 +11,29 @@ exports.selectAllTopics = () => {
     return db.query(queryStr)
 }
 
+exports.selectAllArticles = () => {
+    let queryStr = `SELECT articles.article_id, articles.author, title, topic, articles.created_at, articles.votes, article_img_url, COUNT (comments.comment_id) AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id GROUP BY articles.article_id;`
+
+    return db.query(queryStr)
+}
+
 exports.selectArticleById = (id) => {
     let queryStr = `SELECT * FROM articles`
 
     queryStr += ` WHERE article_id = ${id}`
 
     return db.query(queryStr)
+    .then(({ rows }) => {
+        if (rows.length === 0) {
+            return Promise.reject({status: 404, msg: 'article_id does not exist'})
+        } else {
+            return rows[0]
+        }
+    })
+    .catch((err) => {
+        if (err.code === '42703') {
+            err = {status: 404, msg: 'Invalid article_id'}
+        }
+        return Promise.reject({status: err.status, msg: err.msg})
+    })
 }


### PR DESCRIPTION
Added endpoint '/api/articles' where the endpoint returns the article_id, title, topic, author, created_at, votes and the article_image_url, comment_count of all the articles for the happy path.

Same error handling for a 404 error

Also responded to the feedback moving all interactions with the data and the database to the models and adding a further test.
