### PR TITLE
Added endpoint '/api/articles/:article_id/comments' with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -33,8 +33,10 @@ describe("/api/topics",()=>{
                     const {topics} = body
                     expect(topics.length).toBe(3)
                     topics.forEach((topics)=>{
-                        expect(typeof topics.slug).toBe("string")
-                        expect(typeof topics.description).toBe("string")
+                        expect.objectContaining({
+                            slug: expect.any(String),
+                            description: expect.any(String)
+                        })
                     })
                 })
     })
@@ -49,14 +51,16 @@ describe("/api/articles",()=>{
                     const {articles} = body
                     expect(articles.length).toBe(13)
                     articles.forEach((article)=>{
-                        expect(typeof article.article_id).toBe("number")
-                        expect(typeof article.author).toBe("string")
-                        expect(typeof article.title).toBe("string")
-                        expect(typeof article.topic).toBe("string")
-                        expect(typeof article.created_at).toBe("string")
-                        expect(typeof article.votes).toBe("number")
-                        expect(typeof article.article_img_url).toBe("string")
-                        expect(typeof article.comment_count).toBe("string")
+                        expect.objectContaining({
+                            article_id: expect.any(Number),
+                            author: expect.any(String),
+                            title: expect.any(String),
+                            topic: expect.any(String),
+                            created_at: expect.any(String),
+                            votes: expect.any(Number),
+                            article_img_url: expect.any(String),
+                            comment_count: expect.any(String),
+                        })
                     })
                 })
     })
@@ -69,13 +73,18 @@ describe("/api/articles/:article_id",()=>{
             .expect(200)
                 .then(({body})=>{
                     const {article} = body
-                    expect(article.title).toBe("Living in the shadow of a great man")
-                    expect(article.topic).toBe("mitch")
-                    expect(article.author).toBe("butter_bridge")
-                    expect(article.body).toBe("I find this existence challenging")
-                    expect(article.created_at).toBe("2020-07-09T20:11:00.000Z")
-                    expect(article.votes).toBe(100)
-                    expect(article.article_img_url).toBe("https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700")
+
+                    const desiredArticle =   {
+                        title: "Living in the shadow of a great man",
+                        topic: "mitch",
+                        author: "butter_bridge",
+                        body: "I find this existence challenging",
+                        created_at: "2020-07-09T20:11:00.000Z",
+                        votes: 100,
+                        article_img_url: "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+                    }
+
+                    expect(article).toMatchObject(desiredArticle)
                 })
     })
     test("GET 404 when given an valid but non-existent article_id",()=>{
@@ -90,6 +99,54 @@ describe("/api/articles/:article_id",()=>{
     test("GET 404 when given an valid but non-existent article_id",()=>{
         return request(app)
             .get("/api/articles/banana")
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Invalid article_id")
+                })
+    })
+})
+
+describe("/api/articles/:article_id/comments",()=>{
+    test("GET 200 and the requested article by id", () => {
+        return request(app)
+            .get("/api/articles/1/comments")
+            .expect(200)
+                .then(({body})=>{
+                    const {comments} = body
+                    comments.forEach(comment => {
+                        expect.objectContaining({
+                            comment_id: expect.any(Number),
+                            votes: expect.any(Number),
+                            created_at: expect.any(String),
+                            author: expect.any(String),
+                            body: expect.any(String),
+                            article_id: expect.any(Number),
+                        })
+                    })
+                })
+    })
+    test("GET 404 when given an valid article_id but it doesn't have any comments",()=>{
+        return request(app)
+            .get("/api/articles/7/comments")
+            .expect(200)  // Not sure what status code to use as there is an article but no comments
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("There are no comments on this article")
+                })
+    })
+    test("GET 404 when given an valid but non-existent article_id",()=>{
+        return request(app)
+            .get("/api/articles/100/comments")
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("article_id does not exist")
+                })
+    })
+    test("GET 404 when given an valid but non-existent article_id",()=>{
+        return request(app)
+            .get("/api/articles/banana/comments")
             .expect(404)
                 .then(({body})=>{
                     const {msg} = body

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId } = require("./controllers/controllers")
 
 // app.use(express.json())
 
@@ -12,6 +12,8 @@ app.get('/api/topics', getAllTopics)
 app.get('/api/articles', getAllArticles)
 
 app.get('/api/articles/:article_id', getArticleById)
+
+app.get('/api/articles/:article_id/comments', getAllCommentsFromArticleId)
 
 
 app.use((req, res, next) => {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,4 @@
-const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles }= require("../models/models")
+const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId }= require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -36,6 +36,23 @@ exports.getArticleById = (req, res, next) => {
         res.status(200).send({article})
     })
     .catch((err) => {
+        if (err.code === '42703') {
+            err = {status: 404, msg: 'Invalid article_id'}
+        }
+        next(err)
+    })
+}
+
+exports.getAllCommentsFromArticleId = (req, res, next) => {
+    const { article_id } = req.params
+    selectAllCommentsFromArticleId(article_id)
+    .then (( comments ) => {
+        res.status(200).send({comments})
+    })
+    .catch((err) => {
+        if (err.code === '42703') {
+            err = {status: 404, msg: 'Invalid article_id'}
+        }
         next(err)
     })
 }

--- a/models/models.js
+++ b/models/models.js
@@ -30,10 +30,26 @@ exports.selectArticleById = (id) => {
             return rows[0]
         }
     })
-    .catch((err) => {
-        if (err.code === '42703') {
-            err = {status: 404, msg: 'Invalid article_id'}
+}
+
+exports.selectAllCommentsFromArticleId = (id) => {
+    let queryStr = `SELECT * FROM comments`
+
+    queryStr += ` WHERE article_id = ${id}`
+
+    return db.query(queryStr)
+    .then(({ rows }) => {
+        if (rows.length === 0) {
+            return this.selectArticleById(id)
+            .then((article) => {
+                if (article.length === 0) {
+                    return Promise.reject({ status: 404, msg: 'article_id does not exist' });
+                } else {
+                    return Promise.reject({ status: 200, msg: 'There are no comments on this article'})
+                }
+            })
+        } else {
+            return rows
         }
-        return Promise.reject({status: err.status, msg: err.msg})
     })
 }


### PR DESCRIPTION
Added endpoint '/api/articles' where the endpoint returns the comment_id, votes, created_at, author, body and the article_id of all the specific article for the happy path.

Included errors for valid yet non-existent articles and invalid articles, also gives a 200 for valid and existing articles with no comments

Also responded to the feedback moving all catch into the controllers and changing the jest matches for some tests