### PR TITLE
Added endpoint '/api/articles/:article_id/comments' to post new comment with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -108,6 +108,7 @@ describe("/api/articles/:article_id",()=>{
 })
 
 describe("/api/articles/:article_id/comments",()=>{
+    // GET
     test("GET 200 and the requested article by id", () => {
         return request(app)
             .get("/api/articles/1/comments")
@@ -153,6 +154,99 @@ describe("/api/articles/:article_id/comments",()=>{
                     expect(msg).toBe("Invalid article_id")
                 })
     })
+
+
+
+    // Post
+    test("POST 201 and the created comment", () => {
+
+        const newComment = {
+            author: "butter_bridge",
+            body: "This is a test comment"
+        }
+
+        return request(app)
+        .post("/api/articles/1/comments")
+        .send(newComment)
+        .expect(201)
+        .then(({body})=>{
+            const {comment} = body
+            
+            const finalComment = {
+                author: "butter_bridge",
+                body: "This is a test comment",
+                article_id: 1
+            }
+            expect(comment).toMatchObject(finalComment)
+        })
+    })
+    test("POST 404 when given an valid but non-existent article_id",()=>{
+
+        const newComment = {
+            author: "butter_bridge",
+            body: "This is a test comment"
+        }
+
+        return request(app)
+            .post("/api/articles/100/comments")
+            .send(newComment)
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("article_id does not exist")
+                })
+    })
+    test("POST 404 when given an valid but non-existent article_id",()=>{
+
+        const newComment = {
+            author: "butter_bridge",
+            body: "This is a test comment"
+        }
+
+        return request(app)
+            .post("/api/articles/banana/comments")
+            .send(newComment)
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Invalid article_id")
+                })
+    })
+
+    test("POST 400 when given an invalid new comment with a invalid value",()=>{
+
+        const newComment = {
+            author: "TedSmiles",
+            body: "This is a test comment"
+        }
+
+        return request(app)
+            .post("/api/articles/1/comments")
+            .send(newComment)
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Not a valid user")
+                })
+    })
+
+    test("POST 400 when given an invalid new comment with a invalid key",()=>{
+
+        const newComment = {
+            john: "butter_bridge",
+            body: "This is a test comment"
+        }
+
+        return request(app)
+            .post("/api/articles/1/comments")
+            .send(newComment)
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Invalid new comment")
+                })
+    })
+
 })
 
 describe("Invalid endpoint", () => {

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId, postNewComment } = require("./controllers/controllers")
 
-// app.use(express.json())
+app.use(express.json())
 
 app.get('/api', getAllEndpoints)
 
@@ -14,6 +14,8 @@ app.get('/api/articles', getAllArticles)
 app.get('/api/articles/:article_id', getArticleById)
 
 app.get('/api/articles/:article_id/comments', getAllCommentsFromArticleId)
+
+app.post('/api/articles/:article_id/comments', postNewComment)
 
 
 app.use((req, res, next) => {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,4 @@
-const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId }= require("../models/models")
+const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId, updateNewComment }= require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -51,6 +51,27 @@ exports.getAllCommentsFromArticleId = (req, res, next) => {
     })
     .catch((err) => {
         if (err.code === '42703') {
+            err = {status: 404, msg: 'Invalid article_id'}
+        }
+        next(err)
+    })
+}
+
+exports.postNewComment = (req, res, next) => {
+    const newComment = req.body
+    const { article_id } = req.params
+    updateNewComment(newComment, article_id)
+    .then((comment) => {
+        res.status(201).send({comment})
+    })
+    .catch((err) => {
+        if (err.code === '23502') {
+            err = {status: 404, msg: 'Invalid new comment'}
+        } else if (err.code === '23503' && err.constraint === 'comments_author_fkey') {
+            err = {status: 404, msg: 'Not a valid user'}
+        } else if (err.code === '23503' && err.constraint == 'comments_article_id_fkey') {
+            err = {status: 404, msg: 'article_id does not exist'}
+        } else if (err.code === '22P02') {
             err = {status: 404, msg: 'Invalid article_id'}
         }
         next(err)

--- a/models/models.js
+++ b/models/models.js
@@ -53,3 +53,21 @@ exports.selectAllCommentsFromArticleId = (id) => {
         }
     })
 }
+
+exports.updateNewComment = (newComment, id) => {
+    const { author, body } = newComment
+
+    return db.query(`
+        INSERT INTO comments
+            (author, body, article_id)
+        VALUES
+            ($1, $2, $3)
+        RETURNING *
+        `, [author, body, id])
+    
+    .then(({ rows }) => {
+        return rows[0]
+    })
+
+
+}


### PR DESCRIPTION
Added endpoint '/api/articles/:article_id/comments' where the endpoint returns the new comment after adding the comment to the comments table for the happy path.

Included errors for valid yet non-existent articles and invalid articles, also when the provided comment using an invalid user or invalid key returns with an appropriate message