### PR TITLE
Added endpoint '/api/articles/:article_id' to update the votes of an article with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -105,6 +105,126 @@ describe("/api/articles/:article_id",()=>{
                     expect(msg).toBe("Invalid article_id")
                 })
     })
+
+
+    // PATCH
+    test("PATCH 201 should increase votes of the specific article and return the article", () => {
+
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(201)
+            .then(({ body }) => {
+                const article = body
+
+                const desiredArticle =   {
+                    title: "Living in the shadow of a great man",
+                    topic: "mitch",
+                    author: "butter_bridge",
+                    body: "I find this existence challenging",
+                    created_at: "2020-07-09T20:11:00.000Z",
+                    votes: 200, // Increment the votes by 100
+                    article_img_url: "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+                }
+
+                expect(article).toMatchObject(desiredArticle)
+            })
+    })
+
+    test("PATCH 201 should decrease votes of the specific article and return the article", () => {
+
+        const newVote = {
+            inc_votes: -100
+        }
+
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(201)
+            .then(({ body }) => {
+                const article = body
+
+                const desiredArticle =   {
+                    title: "Living in the shadow of a great man",
+                    topic: "mitch",
+                    author: "butter_bridge",
+                    body: "I find this existence challenging",
+                    created_at: "2020-07-09T20:11:00.000Z",
+                    votes: 0, // Increment the votes by 100
+                    article_img_url: "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+                }
+
+                expect(article).toMatchObject(desiredArticle)
+            })
+    })
+
+    test("PATCH 400 should return an error when the inc_votes isn't an number", () => {
+
+        const newVote = {
+            inc_votes: "Hi"
+        }
+
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(400)
+        .then(({body})=>{
+            const {msg} = body
+            expect(msg).toBe("New votes need to be a number")
+        })
+    })
+
+    test("PATCH 400 should return an error when the inc_vote isn't correctly formatted", () => {
+
+        const newVote = {
+            John: 100
+        }
+
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(400)
+        .then(({body})=>{
+            const {msg} = body
+            expect(msg).toBe("Invalid new votes")
+        })
+    })
+
+
+    test("PATCH 404 when given an valid but non-existent article_id",()=>{
+    
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+            .patch("/api/articles/100")
+            .send(newVote)
+            .expect(404)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("article_id does not exist")
+                })
+    })
+    test("PATCH 400 when given an invalid article_id",()=>{
+    
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+            .patch("/api/articles/banana")
+            .send(newVote)
+            .expect(400)
+                .then(({body})=>{
+                    const {msg} = body
+                    expect(msg).toBe("Invalid article_id")
+                })
+    })
 })
 
 describe("/api/articles/:article_id/comments",()=>{

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId, postNewComment } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId, postNewComment, patchArticle } = require("./controllers/controllers")
 
 app.use(express.json())
 
@@ -16,6 +16,8 @@ app.get('/api/articles/:article_id', getArticleById)
 app.get('/api/articles/:article_id/comments', getAllCommentsFromArticleId)
 
 app.post('/api/articles/:article_id/comments', postNewComment)
+
+app.patch('/api/articles/:article_id', patchArticle)
 
 
 app.use((req, res, next) => {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,4 @@
-const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId, updateNewComment }= require("../models/models")
+const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId, updateNewComment, updateArticleVotes }= require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -60,6 +60,18 @@ exports.postNewComment = (req, res, next) => {
     updateNewComment(newComment, article_id)
     .then((comment) => {
         res.status(201).send({comment})
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
+
+exports.patchArticle = (req, res, next) => {
+    const newVote = req.body
+    const { article_id } = req.params
+    updateArticleVotes(newVote, article_id)
+    .then((article) => {
+        res.status(201).send(article)
     })
     .catch((err) => {
         next(err)

--- a/models/models.js
+++ b/models/models.js
@@ -68,6 +68,21 @@ exports.updateNewComment = (newComment, id) => {
     .then(({ rows }) => {
         return rows[0]
     })
+}
 
+exports.updateArticleVotes = ({ inc_votes }, id) => {
+    if (inc_votes === undefined) {
+        return Promise.reject({ status: 400, msg: 'Invalid new votes'})
+    } else if (typeof inc_votes !== 'number') {
+        return Promise.reject({ status: 400, msg: 'New votes need to be a number'})
+    }
 
+    return db.query(`UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *`,[inc_votes, id])
+    .then(({rows}) => {
+        if (rows[0] === undefined) {
+            return Promise.reject({ status: 404, msg: 'article_id does not exist'})
+        } else {
+            return rows[0]
+        }
+    })
 }


### PR DESCRIPTION
Added endpoint '/api/articles/:article_id' where the endpoint returns the article after updating the number of votes for the happy path.

Included errors for valid yet non-existent articles and invalid articles, also when the provided an invalid object for the new vote returns an error with an appropriate message