### PR TITLE
Added endpoint '/api/comments/:comment_id' to delete a comment with error handling 

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -396,6 +396,34 @@ describe("/api/articles/:article_id/comments",()=>{
 
 })
 
+
+describe("/api/comments/:comment_id",()=>{  
+    test("DELETE 204, delete the comment from the comment id", () => {
+        return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+    })
+    test("DELETE 404 when given an valid but non-existent article_id", () => {
+        return request(app)
+        .delete("/api/comments/100")
+        .expect(404)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("article_id does not exist")
+        })
+    })
+    test("DELETE 400 when given an invalid article_id", () => {
+        return request(app)
+        .delete("/api/comments/banana")
+        .expect(400)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("Invalid path params")
+        })
+    })
+})
+
+
 describe("Invalid endpoint", () => {
     test("GET 404 where the request is not found", () => {
         return request(app)

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 const express = require("express")
 const app = express()
 
-const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId, postNewComment, patchArticle } = require("./controllers/controllers")
+const { getAllTopics, getAllEndpoints, getArticleById, getAllArticles, getAllCommentsFromArticleId, postNewComment, patchArticle, deleteComment } = require("./controllers/controllers")
 
 app.use(express.json())
 
@@ -18,6 +18,8 @@ app.get('/api/articles/:article_id/comments', getAllCommentsFromArticleId)
 app.post('/api/articles/:article_id/comments', postNewComment)
 
 app.patch('/api/articles/:article_id', patchArticle)
+
+app.delete('/api/comments/:comment_id', deleteComment)
 
 
 app.use((req, res, next) => {

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,12 @@
-const { selectAllTopics, selectAllEndpoints, selectArticleById, selectAllArticles, selectAllCommentsFromArticleId, updateNewComment, updateArticleVotes }= require("../models/models")
+const { 
+    selectAllTopics, 
+    selectAllEndpoints, 
+    selectArticleById, 
+    selectAllArticles, 
+    selectAllCommentsFromArticleId, 
+    updateNewComment, 
+    updateArticleVotes, 
+    deleteSpecificComment } = require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -72,6 +80,17 @@ exports.patchArticle = (req, res, next) => {
     updateArticleVotes(newVote, article_id)
     .then((article) => {
         res.status(200).send({article})
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
+
+exports.deleteComment = (req, res, next) => {
+    const { comment_id } = req.params
+    deleteSpecificComment(comment_id)
+    .then(() => {
+        res.status(204).send()
     })
     .catch((err) => {
         next(err)

--- a/models/models.js
+++ b/models/models.js
@@ -80,3 +80,14 @@ exports.updateArticleVotes = ({ inc_votes }, id) => {
         }
     })
 }
+
+exports.deleteSpecificComment = (id) => {
+    return db.query(`DELETE FROM comments WHERE comment_id = $1 RETURNING *`,[id])
+    .then(({ rows }) => {
+        if (rows[0] === undefined) {
+            return Promise.reject({ status: 404, msg: 'article_id does not exist'})
+        } else {
+            return rows[0]
+        }
+    })
+}


### PR DESCRIPTION
Added endpoint '/api/comments/:comment_id' where the endpoint deletes the comment and returns a 204 status code and no content for the happy path.

For valid yet non-existent articles and invalid articles returns an error with an appropriate message