### PR TITLE
Add query function to previous endpoint '/api/articles' with error handling 

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -64,6 +64,36 @@ describe("/api/articles",()=>{
                     })
                 })
     })
+    test("GET 200 and all articles of a topic (mitch) upon request", () => {
+        return request(app)
+            .get("/api/articles?topic=mitch")
+            .expect(200)
+                .then(({body})=>{
+                    const {articles} = body
+                    expect(articles.length).toBe(12)
+                    articles.forEach((article)=>{
+                        expect(article.topic).toBe('mitch')
+                    })
+                })
+    })
+    test("GET 200 and no articles when passed a valid but non-existent topic", () => {
+        return request(app)
+            .get("/api/articles?topic=toby")
+            .expect(200)
+                .then(({body})=>{
+                    const {articles} = body
+                    expect(articles.length).toBe(0)
+                })
+    })
+    test("GET 200 and all articles when passed anything other than a topic (ignores invalid queries)", () => {
+        return request(app)
+            .get("/api/articles?test=testing")
+            .expect(200)
+                .then(({body})=>{
+                    const {articles} = body
+                    expect(articles.length).toBe(13)
+                })
+    })
 })
 
 describe("/api/articles/:article_id",()=>{

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -38,7 +38,8 @@ exports.getAllUsers = (req, res, next) => {
 }
 
 exports.getAllArticles = (req, res, next) => {
-    selectAllArticles()
+    const { topic } = req.query
+    selectAllArticles(topic)
     .then(( { rows }) => {
         const articles = rows
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -17,7 +17,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
+    "description": "serves an array of all articles with any appropiate queries",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [

--- a/models/models.js
+++ b/models/models.js
@@ -17,10 +17,18 @@ exports.selectAllUser = () => {
     return db.query(queryStr)
 }
 
-exports.selectAllArticles = () => {
-    let queryStr = `SELECT articles.article_id, articles.author, title, topic, articles.created_at, articles.votes, article_img_url, COUNT (comments.comment_id) AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id GROUP BY articles.article_id;`
+exports.selectAllArticles = (topicQuery) => {
+    const queryValues = []
+    let queryStr = `SELECT articles.article_id, articles.author, title, topic, articles.created_at, articles.votes, article_img_url, COUNT (comments.comment_id) AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id`
 
-    return db.query(queryStr)
+    if (topicQuery) {
+        queryValues.push(topicQuery)
+        queryStr += ` WHERE topic = $${queryValues.length}`
+    }
+
+    queryStr += ` GROUP BY articles.article_id`
+
+    return db.query(queryStr, queryValues)
 }
 
 exports.selectArticleById = (id) => {


### PR DESCRIPTION
Added function of querying by topic the endpoint '/api/articles' where the endpoint returns all the articles within the topic and if no topic query then returns all the articles for the happy path.

If there is an invalid query (not topic=) ignore it and just return all articles and if there are no articles with a topic then return nothing