### PR TITLE
Add sorting and ordering function to previous endpoint '/api/articles' with error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4",
         "supertest": "^6.3.4"
       }
@@ -3255,6 +3256,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -7573,6 +7580,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "seed": "node ./db/seeds/run-seed.js",
     "test": "jest",
     "//": "('prepare': 'husky install')"
-    
   },
   "repository": {
     "type": "git",
@@ -27,10 +26,11 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4",
     "supertest": "^6.3.4"
   },
-  "dependencies": {    
+  "dependencies": {
     "dotenv": "^16.0.0",
     "express": "^4.19.2",
     "pg": "^8.7.3"


### PR DESCRIPTION
Added function of sorting and ordering by topic the endpoint '/api/articles' where the endpoint returns all the articles sorted and ordered based on the query (also works with a filter query) for the happy path.

If there is an invalid query ignore it and just return no articles and an error message if the sort_by or order is invalid to prevent SQL injections