### PR TITLE
Added endpoint '/api/articles/:article_id' to update the votes of an article with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -491,6 +491,122 @@ describe("/api/articles/:article_id/comments",()=>{
 
 
 describe("/api/comments/:comment_id",()=>{ 
+    // PATCH
+    test("PATCH 200 should increase votes of the specific comment and return the comment", () => {
+
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+        .patch("/api/comments/3")
+        .send(newVote)
+        .expect(200)
+            .then(({ body }) => {
+                const { comment } = body
+
+                const desiredAComment=   {
+                    body: "Replacing the quiet elegance of the dark suit and tie with the casual indifference of these muted earth tones is a form of fashion suicide, but, uh, call me crazy — onyou it works.",
+                    votes: 200,
+                    author: "icellusedkars",
+                    article_id: 1,
+                    created_at: "2020-03-01T01:13:00.000Z"
+                }
+
+                expect(comment).toMatchObject(desiredAComment)
+            })
+    })
+
+    test("PATCH 200 should decrease votes of the specific article and return the article", () => {
+
+        const newVote = {
+            inc_votes: -100
+        }
+
+        return request(app)
+        .patch("/api/comments/3")
+        .send(newVote)
+        .expect(200)
+            .then(({ body }) => {
+                const { comment } = body
+
+                const desiredComment =   {
+                    body: "Replacing the quiet elegance of the dark suit and tie with the casual indifference of these muted earth tones is a form of fashion suicide, but, uh, call me crazy — onyou it works.",
+                    votes: 0, // decrease votes by 100
+                    author: "icellusedkars",
+                    article_id: 1,
+                    created_at: "2020-03-01T01:13:00.000Z"
+                }
+
+                expect(comment).toMatchObject(desiredComment)
+            })
+    })
+
+    test("PATCH 400 should return an error when the inc_votes isn't an number", () => {
+
+        const newVote = {
+            inc_votes: "Hi"
+        }
+
+        return request(app)
+        .patch("/api/comments/3")
+        .send(newVote)
+        .expect(400)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("Invalid path params")
+        })
+    })
+
+    test("PATCH 400 should return an error when the inc_vote isn't correctly formatted", () => {
+
+        const newVote = {
+            John: 100
+        }
+
+        return request(app)
+        .patch("/api/comments/1")
+        .send(newVote)
+        .expect(400)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("Invalid new entry")
+        })
+    })
+
+
+    test("PATCH 404 when given an valid but non-existent comment_id",()=>{
+    
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+            .patch("/api/comments/100")
+            .send(newVote)
+            .expect(404)
+                .then(({ body })=>{
+                    const { msg } = body
+                    expect(msg).toBe("comment_id does not exist")
+                })
+    })
+    test("PATCH 400 when given an invalid comment_id",()=>{
+    
+        const newVote = {
+            inc_votes: 100
+        }
+
+        return request(app)
+            .patch("/api/comments/banana")
+            .send(newVote)
+            .expect(400)
+                .then(({ body })=>{
+                    const { msg } = body
+                    expect(msg).toBe("Invalid path params")
+                })
+    })
+    
+    // DELETE
     test("DELETE 204, delete the comment from the comment id", () => {
         return request(app)
         .delete("/api/comments/1")

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -8,7 +8,8 @@ const {
     updateArticleVotes, 
     deleteCommentById,
     selectAllUser,
-    selectUserByUsername } = require("../models/models")
+    selectUserByUsername,
+    updateCommentVotes } = require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -101,13 +102,24 @@ exports.patchArticle = (req, res, next) => {
     const { article_id } = req.params
     updateArticleVotes(newVote, article_id)
     .then((article) => {
-        res.status(200).send({article})
+        res.status(200).send({ article })
     })
     .catch((err) => {
         next(err)
     })
 }
 
+exports.patchComment = (req, res, next) => {
+    const newVote = req.body
+    const { comment_id } = req.params
+    updateCommentVotes(newVote, comment_id)
+    .then((comment) => {
+        res.status(200).send({ comment })
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
 exports.deleteComment = (req, res, next) => {
     const { comment_id } = req.params
     deleteCommentById(comment_id)

--- a/endpoints.json
+++ b/endpoints.json
@@ -106,6 +106,22 @@
       ]
     }
   },
+  "PATCH /api/comments/:comment_id": {
+    "description": "updates the votes by an increment passed in",
+    "queries": ["comment_id"],
+    "sentBody": { "inc_votes": 100},
+    "exampleResponse": {
+      "comment": [
+        {
+          "body": "Replacing the quiet elegance of the dark suit and tie with the casual indifference of these muted earth tones is a form of fashion suicide, but, uh, call me crazy — onyou it works.",
+          "votes": 200,
+          "author": "icellusedkars",
+          "article_id": 1,
+          "created_at": "2020-03-01T01:13:00.000Z"
+        }
+      ]
+    }
+  },
   "DELETE /api/comments/:comment_id" : {
     "description": "deletes a request comment and responds with a 204",
     "queries": ["comment_id"]

--- a/models/models.js
+++ b/models/models.js
@@ -151,6 +151,17 @@ exports.updateArticleVotes = ({ inc_votes }, id) => {
     })
 }
 
+exports.updateCommentVotes = ({ inc_votes }, id) => {
+    return db.query(`UPDATE comments SET votes = votes + $1 WHERE comment_id = $2 RETURNING *`,[inc_votes, id])
+    .then(({ rows }) => {
+        if (rows[0] === undefined) {
+            return Promise.reject({ status: 404, msg: 'comment_id does not exist'})
+        } else {
+            return rows[0]
+        }
+    })
+}
+
 exports.deleteCommentById = (id) => {
     return db.query(`DELETE FROM comments WHERE comment_id = $1 RETURNING *`,[id])
     .then(({ rows }) => {

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -1,9 +1,10 @@
 const commentRouter = require('express').Router()
 
-const { deleteComment } = require("../controllers/controllers")
+const { deleteComment, patchComment } = require("../controllers/controllers")
 
 commentRouter
     .route('/:comment_id')
+    .patch(patchComment)
     .delete(deleteComment)    
 
 module.exports = commentRouter


### PR DESCRIPTION
Added endpoint '/api/comments/:comment_id' where the endpoint returns the comment after updating the number of votes for the happy path.

Included errors for valid yet non-existent comment_ids and invalid comment_ids, also when the provided an invalid object for the new vote returns an error with an appropriate message