### PR TITLE
Add pages and limits to previous endpoint '/api/articles' with error handling

### DIFF
--- a/endpoints.json
+++ b/endpoints.json
@@ -24,8 +24,8 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles with any appropiate queries",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "description": "serves an array of all articles with any appropiate queries, allows for differnet pages of 10 articles",
+    "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
     "exampleResponse": {
       "articles": [
         {

--- a/models/models.js
+++ b/models/models.js
@@ -37,7 +37,7 @@ exports.selectUserByUsername = (username) => {
 }
 
 exports.selectAllArticles = (query) => {
-    const allowedKeys = ['topic', 'sort_by', 'order']
+    const allowedKeys = ['topic', 'sort_by', 'order', 'limit', 'p']
 
     let validQuery = false
 
@@ -54,6 +54,8 @@ exports.selectAllArticles = (query) => {
     const { topic } = query
     const { sort_by = 'created_at' } = query
     const { order = 'DESC' } = query
+    const { limit = 10 } = query
+    const { p: page = 1 }  = query
 
     if(!['ASC', 'DESC'].includes(order.toUpperCase())) {
         return Promise.reject({status: 400, msg: 'Invalid order query'})
@@ -73,7 +75,14 @@ exports.selectAllArticles = (query) => {
 
     queryStr += ` GROUP BY articles.article_id`
     
-    queryStr += ` ORDER BY articles.${sort_by} ${order.toUpperCase()}`
+    queryStr += ` ORDER BY articles.${sort_by} ${order.toUpperCase()} LIMIT ${limit}`
+
+    let offset = (page - 1) * 10
+    if(offset < 0) {
+        return Promise.reject({status: 400, msg: 'Invalid page number'})
+    }
+
+    queryStr += ` OFFSET ${offset}`
 
     return db.query(queryStr, queryValues)
     .then(({ rows }) => {


### PR DESCRIPTION
Added function of pages with limits to the endpoint '/api/articles' where the endpoint returns a default of 10 of the articles and allows for you to skip the first 10 and move to the next page for the happy path.

If there is a page number that's too big response with an invalid query and if the page numberisf negative then there is a response that say it's an invalid page number