### PR TITLE
Added endpoint '/api/articles/:article_id' to delete a comment with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -560,6 +560,58 @@ describe("/api/articles/:article_id",()=>{
                     expect(msg).toBe("Invalid path params")
                 })
     })
+
+    // DELETE
+    test("DELETE 204, delete the article from the article_id", () => {
+        return request(app)
+        .delete("/api/articles/1")
+        .expect(204)
+        .then(()=> {
+            return request(app)
+                .get("/api/articles?limit=15")
+                .expect(200)
+                    .then(({ body })=>{
+                        const { articles } = body
+                        expect(articles.length).toBe(12)
+                    })
+        })
+    })
+    test("DELETE 204, when article deleted, all it comments are deleted", () => {
+        return request(app)
+        .delete("/api/articles/1")
+        .expect(204)
+        .then(()=> {
+            const newVote = {
+                inc_votes: 100
+            }
+            return request(app)
+                .patch("/api/comments/2")
+                .send(newVote)
+                .expect(404)
+                .then(({ body })=>{
+                    const { msg } = body
+                    expect(msg).toBe("comment_id does not exist")
+                })
+        })
+    })
+    test("DELETE 404 when given an valid but non-existent article_id", () => {
+        return request(app)
+        .delete("/api/articles/100")
+        .expect(404)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("article_id does not exist")
+        })
+    })
+    test("DELETE 400 when given an invalid article_id", () => {
+        return request(app)
+        .delete("/api/articles/banana")
+        .expect(400)
+        .then(({ body })=>{
+            const { msg } = body
+            expect(msg).toBe("Invalid path params")
+        })
+    })
 })
 
 describe("/api/articles/:article_id/comments",()=>{

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -11,7 +11,8 @@ const {
     selectUserByUsername,
     updateCommentVotes,
     updateNewArticle,
-    updateNewTopic } = require("../models/models")
+    updateNewTopic,
+    deleteArticlesById } = require("../models/models")
 
 exports.getAllEndpoints = (req, res, next) => {
     const endpoints = selectAllEndpoints()
@@ -128,6 +129,17 @@ exports.postNewArticle = (req, res, next) => {
     updateNewArticle(newArticle)
     .then((article) => {
         res.status(201).send({ article })
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
+
+exports.deleteArticle = (req, res, next) => {
+    const { article_id } = req.params
+    deleteArticlesById(article_id)
+    .then(() => {
+        res.status(204).send()
     })
     .catch((err) => {
         next(err)

--- a/db/seeds/seed.js
+++ b/db/seeds/seed.js
@@ -52,7 +52,7 @@ const seed = ({ topicData, userData, articleData, commentData }) => {
       CREATE TABLE comments (
         comment_id SERIAL PRIMARY KEY,
         body VARCHAR NOT NULL,
-        article_id INT REFERENCES articles(article_id) NOT NULL,
+        article_id INT REFERENCES articles(article_id) ON DELETE CASCADE NOT NULL ,
         author VARCHAR REFERENCES users(username) NOT NULL,
         votes INT DEFAULT 0 NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()

--- a/endpoints.json
+++ b/endpoints.json
@@ -108,6 +108,10 @@
         }
     }
   },
+  "DELETE /api/articles/:article_id": {
+    "description": "deletes a request article and all its comments and responds with a 204",
+    "queries": ["article_id"]
+  },
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of differnet pages of 10 comments on the requested article",
     "queries": ["article_id", "limit",  "p"],

--- a/models/models.js
+++ b/models/models.js
@@ -228,6 +228,17 @@ exports.updateNewArticle = (newArticle) => {
     })
 }
 
+exports.deleteArticlesById = (id) => {
+    return db.query(`DELETE FROM articles WHERE article_id = $1 RETURNING *`,[id])
+    .then(({ rows }) => {
+        if (rows[0] === undefined) {
+            return Promise.reject({ status: 404, msg: 'article_id does not exist'})
+        } else {
+            return rows[0]
+        }
+    })
+}
+
 exports.updateCommentVotes = ({ inc_votes }, id) => {
     return db.query(`UPDATE comments SET votes = votes + $1 WHERE comment_id = $2 RETURNING *`,[inc_votes, id])
     .then(({ rows }) => {

--- a/routes/articles-router.js
+++ b/routes/articles-router.js
@@ -1,6 +1,6 @@
 const articleRouter = require('express').Router()
 
-const {  getArticleById, getAllArticles, patchArticle, getAllCommentsFromArticleId, postNewComment, postNewArticle } = require("../controllers/controllers")
+const {  getArticleById, getAllArticles, patchArticle, getAllCommentsFromArticleId, postNewComment, postNewArticle, deleteArticle } = require("../controllers/controllers")
 
 articleRouter
     .route('/')
@@ -11,6 +11,7 @@ articleRouter
     .route('/:article_id')
     .get(getArticleById)
     .patch(patchArticle)
+    .delete(deleteArticle)
     
 
 articleRouter


### PR DESCRIPTION
Added endpoint '/api/articles/:article_id' where the endpoint deletes the articles and all te comment linked to it and returns a 204 status code and no content for the happy path.

For valid yet non-existent articles and invalid articles returns an error with an appropriate message